### PR TITLE
style: unify writing pane background with Excalidraw

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -27,7 +27,7 @@
        ============================================================ */
     :root {
       --font: 'Caveat', cursive;
-      --bg: #faf8f5;
+      --bg: #fefefe;
       --surface: #ffffff;
       --sidebar-bg: #1e1e2e;
       --sidebar-text: #cdd6f4;
@@ -45,7 +45,7 @@
       --orange: #df8e1d;
       --purple: #8839ef;
       --purple-soft: rgba(136,57,239,0.12);
-      --dot-color: #d5d0c8;
+      --dot-color: #e0ddd8;
       --shadow-sm: 0 2px 8px rgba(0,0,0,0.06);
       --shadow-md: 0 4px 20px rgba(0,0,0,0.1);
       --radius: 12px;
@@ -356,7 +356,7 @@
     .page-toolbar .separator { width: 1px; height: 22px; background: var(--border); margin: 0 2px; }
   </style>
 </head>
-<body class="dot-grid-bg">
+<body>
 
 <!-- ===== SIDEBAR ===== -->
 <div class="sidebar">
@@ -391,7 +391,7 @@
 
 <!-- ===== MAIN ===== -->
 <div class="main-area">
-  <div class="content-scroll dot-grid-bg">
+  <div class="content-scroll">
 
     <!-- EDITOR PAGE -->
     <div class="page-view active" id="page-editor">


### PR DESCRIPTION
## Summary

- Changes `--bg` from `#faf8f5` (warm off-white) to `#fefefe` to match Excalidraw's `viewBackgroundColor`
- Removes dot-grid pattern from body and content scroll area
- Text and drawings now sit on the same seamless white background

## Test plan

- [x] All 10 e2e tests pass
- [ ] Manual: writing pane and drawing blocks share the same background color